### PR TITLE
Fix #31 - 修复查找不到帖子时show的500错误。

### DIFF
--- a/web/controllers/post_controller.ex
+++ b/web/controllers/post_controller.ex
@@ -96,7 +96,7 @@ defmodule ElixirChina.PostController do
 
   defp get_loaded_post(id) do
     query = from(c in Post, where: c.id == ^id, preload: [:user, :category])
-    hd(Repo.all(query))
+    List.first(Repo.all(query))
   end
 
   defp get_comments_with_loaded_user(id) do


### PR DESCRIPTION
404页面应该更好，但是还没有统一的404 页面，先修复这个500.